### PR TITLE
Improve args of commandTester by making event props to partial

### DIFF
--- a/commands/mention/tester.ts
+++ b/commands/mention/tester.ts
@@ -6,7 +6,10 @@ import { createMessageBasedResponderContextMock } from "../../test_utils.ts";
 import { randomChoice } from "../../utils.ts";
 
 type Context = Omit<MentionCommandContext, "match">;
-type CreateContext = (text: string, ctx?: Partial<Context>) => Context;
+type PartialContext = Partial<
+  Omit<Context, "event"> & { event: Partial<Omit<Context["event"], "text">> }
+>;
+type CreateContext = (text: string, ctx?: PartialContext) => Context;
 type Dispatch = (c: Context) => MaybePromise<BotResponse>;
 
 export function createMentionCommandTester(): { createContext: CreateContext };

--- a/commands/mention/tester_test.ts
+++ b/commands/mention/tester_test.ts
@@ -1,0 +1,29 @@
+import { assert, assertEquals } from "../../dev_deps.ts";
+import { createMentionCommandTester } from "./tester.ts";
+import { createMentionCommand } from "./command_factory.ts";
+
+Deno.test("createMentionCommandTester: createContext", () => {
+  const { createContext } = createMentionCommandTester();
+
+  let ctx = createContext("hello");
+  assertEquals(ctx.event.text, "hello");
+
+  ctx = createContext("hello", { event: { channelId: "OVERRIDE_CHANNEL_ID" } });
+  assertEquals(ctx.event.channelId, "OVERRIDE_CHANNEL_ID");
+});
+
+Deno.test("createMentionCommandTester: dispatch", async () => {
+  const dummy = createMentionCommand({
+    name: "dummy",
+    examples: ["dummy - dummy"],
+    pattern: /^dummy$/,
+    execute: (c) => c.res.message("receive dummy!"),
+  });
+  const { createContext, dispatch } = createMentionCommandTester(dummy);
+  const ctx = createContext("<@BOT> dummy");
+
+  const res = await dispatch(ctx);
+
+  assert(res.type === "message");
+  assertEquals(res.text, "receive dummy!");
+});

--- a/commands/message/tester.ts
+++ b/commands/message/tester.ts
@@ -6,7 +6,10 @@ import { createMessageBasedResponderContextMock } from "../../test_utils.ts";
 import { randomChoice } from "../../utils.ts";
 
 type Context = Omit<MessageCommandContext, "match">;
-type CreateContext = (text: string, ctx?: Partial<Context>) => Context;
+type PartialContext = Partial<
+  Omit<Context, "event"> & { event: Partial<Omit<Context["event"], "text">> }
+>;
+type CreateContext = (text: string, ctx?: PartialContext) => Context;
 type Dispatch = (c: Context) => MaybePromise<BotResponse>;
 
 export function createMessageCommandTester(): { createContext: CreateContext };

--- a/commands/message/tester_test.ts
+++ b/commands/message/tester_test.ts
@@ -1,0 +1,29 @@
+import { assert, assertEquals } from "../../dev_deps.ts";
+import { createMessageCommandTester } from "./tester.ts";
+import { createMessageCommand } from "./command_factory.ts";
+
+Deno.test("createMentionCommandTester: createContext", () => {
+  const { createContext } = createMessageCommandTester();
+
+  let ctx = createContext("hello");
+  assertEquals(ctx.event.text, "hello");
+
+  ctx = createContext("hello", { event: { channelId: "OVERRIDE_CHANNEL_ID" } });
+  assertEquals(ctx.event.channelId, "OVERRIDE_CHANNEL_ID");
+});
+
+Deno.test("createMentionCommandTester: dispatch", async () => {
+  const dummy = createMessageCommand({
+    name: "dummy",
+    examples: ["dummy - dummy"],
+    pattern: /^dummy$/,
+    execute: (c) => c.res.message("receive dummy!"),
+  });
+  const { createContext, dispatch } = createMessageCommandTester(dummy);
+  const ctx = createContext("dummy");
+
+  const res = await dispatch(ctx);
+
+  assert(res.type === "message");
+  assertEquals(res.text, "receive dummy!");
+});

--- a/commands/reaction/tester.ts
+++ b/commands/reaction/tester.ts
@@ -5,9 +5,14 @@ import { BotResponse, MaybePromise } from "../../types.ts";
 import { createMessageBasedResponderContextMock } from "../../test_utils.ts";
 import { randomChoice } from "../../utils.ts";
 
+type PartialContext = Partial<
+  Omit<ReactionCommandContext, "event"> & {
+    event: Partial<Omit<ReactionCommandContext["event"], "emoji">>;
+  }
+>;
 type CreateContext = (
   emoji: string,
-  ctx?: Partial<ReactionCommandContext>,
+  ctx?: PartialContext,
 ) => ReactionCommandContext;
 type Dispatch = (c: ReactionCommandContext) => MaybePromise<BotResponse>;
 

--- a/commands/reaction/tester_test.ts
+++ b/commands/reaction/tester_test.ts
@@ -1,0 +1,29 @@
+import { assert, assertEquals } from "../../dev_deps.ts";
+import { createReactionCommandTester } from "./tester.ts";
+import { createReactionCommand } from "./command_factory.ts";
+
+Deno.test("createMentionCommandTester: createContext", () => {
+  const { createContext } = createReactionCommandTester();
+
+  let ctx = createContext("owl");
+  assertEquals(ctx.event.emoji, "owl");
+
+  ctx = createContext("owl", { event: { channelId: "OVERRIDE_CHANNEL_ID" } });
+  assertEquals(ctx.event.channelId, "OVERRIDE_CHANNEL_ID");
+});
+
+Deno.test("createMentionCommandTester: dispatch", async () => {
+  const owl = createReactionCommand({
+    name: "owl",
+    examples: [":owl: - hoot!"],
+    emojis: ["owl"],
+    execute: (c) => c.res.message("hoot!"),
+  });
+  const { createContext, dispatch } = createReactionCommandTester(owl);
+  const ctx = createContext("owl");
+
+  const res = await dispatch(ctx);
+
+  assert(res.type === "message");
+  assertEquals(res.text, "hoot!");
+});

--- a/dev_deps.ts
+++ b/dev_deps.ts
@@ -1,4 +1,5 @@
 export {
+  assert,
   assertEquals,
   assertExists,
   assertInstanceOf,


### PR DESCRIPTION
BEFORE

```ts
const {createContext} = createMentionCommandTester();
// error: TS2740 [ERROR]: Type '{ threadTs: sting; }' is missing the following properties from type 'MessageBotEvent': type, userId, channelId, channelType, and 2 more.
const ctx = createContext("<@bot> mention text", {event: {threadTs: "12345"}})
```

AFTER

```ts
const {createContext} = createMentionCommandTester();
const ctx = createContext("<@bot> mention text", {event: {threadTs: "12345"}})
```