### PR TITLE
Add commandName validation in command.ts

### DIFF
--- a/utils.ts
+++ b/utils.ts
@@ -4,3 +4,7 @@
 export const randomChoice = <T>(items: T[]): T => {
   return items[Math.floor(Math.random() * items.length)];
 };
+
+export const lowerCamelToSnake = (str: string): string => {
+  return str.replace(/([A-Z])/g, "_$1").toLowerCase();
+};

--- a/utils_test.ts
+++ b/utils_test.ts
@@ -1,6 +1,14 @@
+import { assertEquals } from "https://deno.land/std@0.180.0/testing/asserts.ts";
 import { assertMatch } from "./dev_deps.ts";
-import { randomChoice } from "./utils.ts";
+import { lowerCamelToSnake, randomChoice } from "./utils.ts";
 
 Deno.test("randomChoice", () => {
   assertMatch(randomChoice(["a", "b", "c", "d"]), /^(a|b|c|d)$/);
+});
+
+Deno.test("snakeToCamel", () => {
+  assertEquals(
+    lowerCamelToSnake("lowerCamelCaseToSnakeCase"),
+    "lower_camel_case_to_snake_case",
+  );
 });


### PR DESCRIPTION
- command name is allowed lowerCamelCase only
- filename is converted to snake_case

BEFORE
```
┗╸❯❯❯ deno run -Ar https://deno.land/x/gbas/command.ts
 ? Select command type (mention) › mention
 ? Input command name › helloWorld
 ? Create a test file? (y/n) › Yes
created bot/mention/helloWorld.ts
created bot/mention/helloWorld_test.ts
```

AFTER
```
┗╸❯❯❯ deno run -Ar https://deno.land/x/gbas/command.ts
 ? Select command type (mention) › mention
 ? Input command name › helloWorld
 ? Create a test file? (y/n) › Yes
created bot/mention/hello_world.ts
created bot/mention/hello_world_test.ts
```