### PR TITLE
Change the default pattern format of command.ts

### DIFF
--- a/command.ts
+++ b/command.ts
@@ -33,7 +33,7 @@ const createMentionCommand = async (
 export const ${name} = createMentionCommand({
   name: "${name}",
   examples: ["${name} <text> - YOUR COMMAND DESCRIPTION"],
-  pattern: /^${name}\\s*(.+)$/i,
+  pattern: /^${name}\\s+(.+)$/i,
   execute: (c) => {
     const text = c.match[1];
     return c.res.message(\`${name} command: \${text}\`);


### PR DESCRIPTION
BEFORE
following messages are all correct:
```
@BOTNAME commandquery
@BOTNAME command query
```

AFTER:
following message is correct:
```
@BOTNAME command query
```

following message is incorrect:
```
@BOTNAME commandquery
```