### PR TITLE
Handle empty userId and prevent validation error in the bot message workflow

### DIFF
--- a/commands/message/slack_function_test.ts
+++ b/commands/message/slack_function_test.ts
@@ -189,6 +189,29 @@ Deno.test(
 );
 
 Deno.test(
+  "it returns none output if the message is sent by the app",
+  async () => {
+    const dispatcher = createDefaultMentionCommandDispatcher();
+    const slackFuncConfig = createMessageCommandSlackFunction({
+      dispatcher,
+      sourceFile: "foo/bar.ts",
+    });
+    const inputs = {
+      channelId: DEFAULT_CHANNEL_ID,
+      channelType: "DUMMYCHANNELTYPE",
+      // this message was sent by app
+      // a value becomes " " because workaround if event.data.user_id is null in message event trigger.
+      userId: " ",
+      message: "hi",
+      messageTs: "1673778812501.0",
+    };
+    const { createContext } = setup({ slackFuncConfig });
+    const res = await slackFuncConfig.func(createContext({ inputs }));
+    assertEquals(res.outputs, { type: "none" });
+  },
+);
+
+Deno.test(
   'it returns "error" output if matched handlers throw error',
   async () => {
     const dispatcher = new MessageCommandDispatcher([

--- a/commands/message/slack_trigger.ts
+++ b/commands/message/slack_trigger.ts
@@ -32,7 +32,8 @@ export function createMessageCommandSlackTrigger(
       messageTs: { value: "{{data.message_ts}}" },
       // temporary workaround (2023/03/20): it responds only in threads if prefix space is nothing
       threadTs: { value: " {{data.thread_ts}}" },
-      userId: { value: "{{data.user_id}}" },
+      // temporary workaround (2023/05/05): data.user_id sometimes returns null then it raises a validation error
+      userId: { value: " {{data.user_id}}" },
     },
   };
   return botMessageTrigger;

--- a/commands/message/slack_workflow.ts
+++ b/commands/message/slack_workflow.ts
@@ -6,7 +6,7 @@ export const messageCommandWorkflowInputParameters = {
   properties: {
     channelId: { type: Schema.slack.types.channel_id },
     channelType: { type: Schema.types.string },
-    userId: { type: Schema.slack.types.user_id },
+    userId: { type: Schema.types.string },
     message: { type: Schema.types.string },
     messageTs: { type: Schema.types.string },
     threadTs: { type: Schema.types.string },
@@ -14,7 +14,6 @@ export const messageCommandWorkflowInputParameters = {
   required: [
     "channelId" as const,
     "channelType" as const,
-    "userId" as const,
     "message" as const,
     "messageTs" as const,
   ],


### PR DESCRIPTION
- It raised the following error when the bot sent a message that changed username and icon_emoji.
- The cause of the error was a message that above included data.user_id that is null
- I guess the message may be from App if data.user_id is null, so I changed the bot message workflow ignores messages like this

```
UNKNOWN LOG EVENT TYPE (trigger_executed)
{
  "trace_id": "Tr00",
  "level": "error",
  "event_type": "trigger_executed",
  "source": "slack",
  "component_type": "workflows",
  "component_id": "---",
  "payload": {
    "errors": "[\"Validation for parameter `userId` failed: value is not a user ID\"]",
    "reason": "parameter_validation_failed",
    "workflow_name": "Bot message workflow"
  },
  "created": 11111111111111
}
```